### PR TITLE
Katselija can edit tutkimus related entities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,7 +114,19 @@ KYPPI_PASSWORD=<kyppi_password>
 KYPPI_MUINAISJAANNOS_URI=<kyppi_mjr_uri>
 # Endpoint
 KYPPI_MUINAISJAANNOS_ENDPOINT=<kyppi_mjr_endpoint>
+# Maakunnat joiden alueelta kohteita haetaan. Arvot erotetaan pilkulla
+KYPPI_HAKU_MAAKUNNAT = ""
+# Kunnat joiden alueelta kohteita haetaan. Arvot erotetaan pilkulla
+KYPPI_HAKU_KUNNAT = ""
 
 ## FINNA integration ##
 FINNA_ADMIN_EMAIL=<mip_yllapidon_email>
 FINNA_HAKUMAARA=<finna_lkm>
+FINNA_IDENTIFIER=<repo_identifier>
+FINNA_ORGANISATION=<repo_organisation>
+FINNA_ARKEOLOGINEN_KOKOELMA="Arkeologinen kokoelma"
+FINNA_KOKOELMA=Kokoelma
+FINNA_MUSEO_URL=<provider_museum_url>
+FINNA_REPOSITORY_NAME=<Repository_name>
+FINNA_REPOSITORY_IDENTIFIER=<Repository_identifier>
+

--- a/config/app.php
+++ b/config/app.php
@@ -311,8 +311,17 @@ return [
     'kyppi_password' => env('KYPPI_PASSWORD'),
     'kyppi_muinaisjaannos_uri' => env('KYPPI_MUINAISJAANNOS_URI'),
     'kyppi_muinaisjaannos_endpoint' => env('KYPPI_MUINAISJAANNOS_ENDPOINT'),
+    'kyppi_haku_maakunnat' => env('KYPPI_HAKU_MAAKUNNAT'),
+    'kyppi_haku_kunnat' => env('KYPPI_HAKU_KUNNAT'),
 
     'finna_admin_email' => env('FINNA_ADMIN_EMAIL'),
-    'finna_hakumaara' => env('FINNA_HAKUMAARA')
+    'finna_hakumaara' => env('FINNA_HAKUMAARA'),
+    'finna_identifier' => env('FINNA_IDENTIFIER'),
+    'finna_organisation' => env('FINNA_ORGANISATION'),
+    'finna_arkeologinen_kokoelma' => env('FINNA_ARKEOLOGINEN_KOKOELMA'),
+    'finna_kokoelma' => env('FINNA_KOKOELMA'),
+    'finna_museo_url' => env('FINNA_MUSEO_URL'),
+    'finna_repository_name' => env('FINNA_REPOSITORY_NAME'),
+    'finna_repository_identifier' => env('FINNA_REPOSITORY_IDENTIFIER')
 
 ];


### PR DESCRIPTION
Setting tutkimus ready=true&public=true attributes do not remove
the katselija user edit permissions anymore.