### PR TITLE
13098 korien poistaminen

### DIFF
--- a/app/Http/Controllers/KoriController.php
+++ b/app/Http/Controllers/KoriController.php
@@ -326,8 +326,6 @@ class KoriController extends Controller
 
 			$kori->save();
 
-            log::debug($kori);
-
             DB::commit();
 
             MipJson::addMessage(Lang::get('kori.delete_success'));

--- a/app/Http/Controllers/KoriController.php
+++ b/app/Http/Controllers/KoriController.php
@@ -312,9 +312,23 @@ class KoriController extends Controller
     public function destroy($id) {
 
         try {
+            
+            DB::beginTransaction();
+			Utils::setDBUser();
+
             $kori = Kori::find($id);
 
-            $kori->delete();
+
+            $author_field = Kori::DELETED_BY;
+			$when_field = Kori::DELETED_AT;
+			$kori->$author_field = Auth::user ()->id;
+			$kori->$when_field = \Carbon\Carbon::now();
+
+			$kori->save();
+
+            log::debug($kori);
+
+            DB::commit();
 
             MipJson::addMessage(Lang::get('kori.delete_success'));
 

--- a/app/Kori.php
+++ b/app/Kori.php
@@ -31,6 +31,9 @@ class Kori extends Model
     const CREATED_BY		= 'luoja';
     const UPDATED_BY		= 'muokkaaja';
 
+    const DELETED_AT 		= "poistettu";
+    const DELETED_BY		= 'poistaja';
+    
     /**
      * Haku id:n mukaan.
      */
@@ -49,25 +52,25 @@ class Kori extends Model
      * Kaikkien haku
      */
     public static function getAll($id) {
-        return self::select('kori.*');
+        return self::select('kori.*')->whereNull('poistettu');
     }
 
     /**
      * Käyttäjän korit
      */
     public static function haeKayttajanKorit($id) {
-        return self::select('kori.*')->where('luoja', '=', $id)->orderBy('nimi', 'asc');
+        return self::select('kori.*')->where('luoja', '=', $id)->whereNull('poistettu')->orderBy('nimi', 'asc');
     }
 
     /**
      * Suodatukset
      */
     public function scopeWithKorityyppi($query, $id) {
-        return $query->where('korityyppi_id', '=', $id);
+        return $query->where('korityyppi_id', '=', $id)->whereNull('poistettu');
     }
 
     public function scopeWithKoriNimi($query, $nimi){
-        return $query->where('nimi', 'ILIKE', $nimi);
+        return $query->where('nimi', 'ILIKE', $nimi)->whereNull('poistettu');
     }
 
     /**

--- a/database/migrations/2022_04_21_150254_kori_poistettu.php
+++ b/database/migrations/2022_04_21_150254_kori_poistettu.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class KoriPoistettu extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('kori', function($table) {
+            $table->integer('poistaja')->nullable();
+            $table->timestamp('poistettu')->nullable();
+        });
+        //
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('kori', function($table) {
+            $table->dropColumn('poistaja');
+            $table->dropColumn('poistettu');
+        });//
+    }
+}


### PR DESCRIPTION
Tehty migraatio, joka lisää kori-tauluun sarakkeet "poistettu" (aikaleima) ja "poistaja" (käyttäjän id). 

Muokattu korien aikaisempi hard delete soft deleteksi ja lisätty korien hakuihin ja filtteröinteihin haettavaksi vain poistamattomia koreja.

Bäkkärissä yksittäisen korin kyselyihin ei ole tehty muutoksia. Tarvitaanko niihin sama lisäys? Käyttäjä navigoi yksittäisen korin näykymään kuitenkin kaikkien korien listauksesta tavalla tai toisella, mikä ottaa poiston huomioon.